### PR TITLE
Feature/frontend/deploy

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload production-ready build files
+        uses: actions/upload-artifact@v3
+        with:
+          name: production-files
+          path: ./dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: production-files
+          path: ./dist
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -42,7 +42,7 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/frontend/deploy'
 
     steps:
       - name: Download artifact

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -30,7 +30,9 @@ jobs:
           working-directory: frontend
 
       - name: Build project
-        run: npm run build
+        run: /
+          cd frontend
+          npm run build
 
       - name: Upload production-ready build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -47,6 +47,10 @@ jobs:
       run:
         working-directory: frontend
     steps:
+      - name: entra na pasta
+        run: |
+          cd frontend
+          
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -49,7 +49,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: production-files
-          path: ./dist
+          path: ./frontend/dist
+          
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -43,14 +43,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/frontend/deploy'
-    defaults:
-      run:
-        working-directory: frontend
+
     steps:
       - name: entra na pasta
         run: |
           cd frontend
-          
+
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -57,4 +57,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ./frontend/dist
+          

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -30,7 +30,7 @@ jobs:
           working-directory: frontend
 
       - name: Build project
-        run: /
+        run: |
           cd frontend
           npm run build
 

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           cd frontend
           npm run build
+          cd ..
 
       - name: Upload production-ready build files
         uses: actions/upload-artifact@v3
@@ -45,10 +46,6 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/frontend/deploy'
 
     steps:
-      - name: entra na pasta
-        run: |
-          cd frontend
-
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/frontend/deploy
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:
@@ -43,7 +40,7 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/frontend/deploy'
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Download artifact

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/frontend/deploy
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: frontend
-        
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -23,8 +23,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
 
+
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
+        with:
+          working-directory: frontend
 
       - name: Build project
         run: npm run build

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -12,9 +12,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
+
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
 
+      - name: Entrar na pasta
+        uses: cd frontend
+
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -12,16 +12,16 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: frontend
+        
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v3
-
-      - name: Entrar na pasta
-        run: cd frontend
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -43,13 +43,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/frontend/deploy'
-
+    defaults:
+      run:
+        working-directory: frontend
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           name: production-files
-          path: ./frontend/dist
+          path: ./dist
           
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -31,13 +31,13 @@ jobs:
         run: |
           cd frontend
           npm run build
-          cd ..
 
       - name: Upload production-ready build files
         uses: actions/upload-artifact@v3
         with:
           name: production-files
-          path: ./dist
+          path: ./frontend/dist
+          if-no-files-found: error
 
   deploy:
     name: Deploy
@@ -50,7 +50,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: production-files
-          path: ./dist
+          path: ./frontend/dist
           
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v3
 
       - name: Entrar na pasta
-        uses: cd frontend
+        run: cd frontend
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "/padaflix/#",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,16 +18,21 @@ import HorariosPadaria from './routes/routesPadaria/HorariosPadaria';
 import PerfilPadaria from './routes/routesPadaria/PerfilPadaria';
 import EnderecoPadaria from './routes/routesPadaria/EnderecoPadaria';
 import PadariaProfile from './routes/PadariaProfile';
+import { useSnackbar } from 'notistack';
 
 function App() {
   const [user, setUser] = useState<User | PadariaUser | undefined>()
-
+  const { enqueueSnackbar } = useSnackbar();
+  
   const fetchUser = async () => {
     axiosInstance.get('/user')
     .then((response) => {
       setUser(response.data);
     })
-    .catch(() => {
+    .catch((err) => {
+      if(!err.response) {
+        enqueueSnackbar('Servidor do padaflix fora do ar', { variant: 'error'})
+      }
       setUser(undefined)
     })
   }

--- a/frontend/src/components/InputPass/index.tsx
+++ b/frontend/src/components/InputPass/index.tsx
@@ -8,7 +8,7 @@ import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 
 interface InputPassProps {
-  onChange: () => void
+  onChange: (e: any) => void
   disabled: boolean
 }
 

--- a/frontend/src/components/NewSubscriptionPlanForm/index.tsx
+++ b/frontend/src/components/NewSubscriptionPlanForm/index.tsx
@@ -1,6 +1,7 @@
 import { useState, SyntheticEvent } from "react";
 import { Button, Container, InputAdornment, Stack, TextField } from "@mui/material";
 import "./styles.scss";
+import { PlanoAssinatura } from "../../types/PlanoAssinatura";
 
 
 interface NewSubscriptionPlanFormProps {

--- a/frontend/src/components/PlanoCard/index.tsx
+++ b/frontend/src/components/PlanoCard/index.tsx
@@ -1,3 +1,4 @@
+import { PlanoAssinatura } from '../../types/PlanoAssinatura';
 import './styles.scss'
 
 interface PlanoCardProps {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,15 +3,15 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 
 import './styles/main.scss'
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import { SnackbarProvider } from 'notistack';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <SnackbarProvider autoHideDuration={4000}>
         <App />
       </SnackbarProvider>
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>,
 )

--- a/frontend/src/routes/Home/index.tsx
+++ b/frontend/src/routes/Home/index.tsx
@@ -9,7 +9,7 @@ function NotLoggedInHome(){
 }
 function UserHome(user: User) {
   return <div>
-    Olá {user.name}
+    Olá {user.nome}
     <PadariasList user={user}/>
   </div>;
 }

--- a/frontend/src/routes/NewSubscriptionPlan/index.tsx
+++ b/frontend/src/routes/NewSubscriptionPlan/index.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from 'notistack';
 import { useNavigate } from "react-router-dom";
 import LinearProgress from '@mui/material/LinearProgress';
 import NewSubscriptionPlanForm from "../../components/NewSubscriptionPlanForm";
+import { PlanoAssinatura } from "../../types/PlanoAssinatura";
 
 
 const NewSubscriptionPlan = () => {

--- a/frontend/src/routes/routesPadaria/PlanosPadaria/index.tsx
+++ b/frontend/src/routes/routesPadaria/PlanosPadaria/index.tsx
@@ -5,6 +5,7 @@ import axiosInstance from '../../../axios';
 import { PadariaUser, User, isPadariaUser } from '../../../types/User';
 import { useEffect, useState } from 'react';
 import PlanoCard from '../../../components/PlanoCard';
+import { PlanoAssinatura } from '../../../types/PlanoAssinatura';
 
 interface PlanosPadariaProps {
     padaria: PadariaUser | User | undefined // talvez receba User ou undefined de App.tsx , o que não queremos.

--- a/frontend/src/types/PlanoAssinatura.ts
+++ b/frontend/src/types/PlanoAssinatura.ts
@@ -1,4 +1,4 @@
-interface PlanoAssinatura{
+export interface PlanoAssinatura{
   nome: string,
   descricao: string,
   preco: number,

--- a/frontend/src/types/User.ts
+++ b/frontend/src/types/User.ts
@@ -1,4 +1,5 @@
 import { Endereco } from "./Endereco";
+import { PlanoAssinatura } from "./PlanoAssinatura";
 
 export interface User {
   id: number,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/padaflix  /'
+  base: '/padaflix/'
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/padaflix/frontend/'
+  base: '/padaflix  /'
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/padaflix/frontend/'
 })


### PR DESCRIPTION
[Pages 🎉](https://andrealvescorreia.github.io/padaflix/)
Deploy do frontend do padaflix para o GitHub Pages usando o Actions!

Em resumo, o actions foi configurado para que sempre que a main mude (push), o actions rode e crie uma build do frontend e realize o deploy numa branch exclusiva para isso: [gh-pages](https://github.com/andrealvescorreia/padaflix/tree/gh-pages)

Para que tudo funcionasse, foi preciso realizar alguns hotfixes no frontend, que foram:
* Corrigir erros de tipagem do Typescript
* Corrigir o react router
  - Ao invés de usar o `<BrowserRouter>` foi necessário usar o `<HashRouter>`. Sendo sincero não sei exatamente a diferença exata entre os dois, pois funcionam de forma praticamente igual.
* Adicionar a configuração ` base: '/padaflix/'` no arquivo `vite.config.ts`
* Adicionar a configuração ` "homepage": "/padaflix/#",` no arquivo `package.json`

Como ainda não foi feito deploy do backend, não é possível se registrar no padaflix, fazer login, etc.

Materiais que me ajudaram a configurar o deploy:
[video](https://www.youtube.com/watch?v=MKw-IriprJY&)
[repositorio peaceiris](https://github.com/peaceiris/actions-gh-pages)
[react router with gh pages](https://stackoverflow.com/questions/71984401/react-router-not-working-with-github-pages)