### PR TITLE
hotfix: can't register when viacep api is offline

### DIFF
--- a/frontend/src/components/AddressForm/index.tsx
+++ b/frontend/src/components/AddressForm/index.tsx
@@ -38,6 +38,7 @@ const AddressForm = ( props : AddressFormProps ) => {
     const [cepIsValid, setCepIsValid] = useState(true)
     const [ruaWasAutoFilled, setRuaWasAutoFilled] = useState(false)
     const [bairroWasAutoFilled, setBairroWasAutoFilled] = useState(false)
+    const [viaCepIsOnline, setViaCepIsOnline] = useState(false);
 
     const handleSubmit = (e : SyntheticEvent) => {
         e.preventDefault()
@@ -82,13 +83,19 @@ const AddressForm = ( props : AddressFormProps ) => {
     function queryCepData(){
         axios.get("https://viacep.com.br/ws/"+ endereco.cep +"/json/")
         .then((response) => {
+            setViaCepIsOnline(true);
             if (response.data.erro) badCepRequest()
             else {
                 setCepIsValid(true)
                 updateEnderecoAfterViaCepQuery(response.data)
             }
         })
-        .catch(() => badCepRequest())
+        .catch((e) => {
+            console.log(e)
+            if(e.code === 'ERR_NETWORK'){
+                setViaCepIsOnline(false);
+            }
+        })
     }
 
     useEffect(() => {
@@ -187,7 +194,7 @@ const AddressForm = ( props : AddressFormProps ) => {
                     )}
                 />
                 <TextField 
-                    disabled
+                    disabled = {viaCepIsOnline}
                     label = "Cidade" 
                     required
                     value = {endereco.cidade}
@@ -197,7 +204,7 @@ const AddressForm = ( props : AddressFormProps ) => {
                 />
 
                 <TextField 
-                    disabled 
+                    disabled = {viaCepIsOnline}
                     label = "UF" 
                     required
                     value = {endereco.uf}


### PR DESCRIPTION
No formulário de endereço, caso a API do ViaCEP estiver offline, os inputs são liberados para o usuário informar seu endereço manualmente, assim ele não fica impedido de se registrar. 
Isso tbm permite que nós desenvolvedores possamos testar o padaflix rodando localmente sem necessidade de conexão com a internet.